### PR TITLE
Add support for '\x1b[1;39m' (bold)

### DIFF
--- a/autoload/AnsiEsc.vim
+++ b/autoload/AnsiEsc.vim
@@ -123,6 +123,7 @@ fun! AnsiEsc#AnsiEsc(rebuild)
   syn region ansiMagenta	start="\e\[;\=0\{0,2};\=35m" end="\e\["me=e-2 contains=ansiConceal
   syn region ansiCyan		start="\e\[;\=0\{0,2};\=36m" end="\e\["me=e-2 contains=ansiConceal
   syn region ansiWhite		start="\e\[;\=0\{0,2};\=37m" end="\e\["me=e-2 contains=ansiConceal
+  syn region ansiBold		start="\e\[;\=0\{0,1}1;\=39m" end="\e\["me=e-2 contains=ansiConceal
 
   syn region ansiBlackBg	start="\e\[;\=0\{0,2};\=\%(1;\)\=40\%(1;\)\=m" end="\e\["me=e-2 contains=ansiConceal
   syn region ansiRedBg		start="\e\[;\=0\{0,2};\=\%(1;\)\=41\%(1;\)\=m" end="\e\["me=e-2 contains=ansiConceal


### PR DESCRIPTION
This escape sequence is not being processed properly by AnsiEsc.
With less, it is displayed with the bold color from urxvt*colorBD.
With AnsiEsc, it is displayed in white, and the 'm' is not concealed (extract from `journalctl -b`):
- with AnsiEsc:

```
kernel: mLinux version
```
- without AnsiEsc:

```
kernel: ^[[1;39mLinux version
```
- with less (imagine 'Linux version' in bold):

```
kernel: Linux version
```

I can fix it by adding to autoload/AnsiEsc.vim (as per the PR):

``` vim
syn region ansiBold start="\e\[;\=0\{0,1}1;\=39m" end="\e\["me=e-2 contains=ansiConceal
```

Also, this may be an incorrect fix since I didn't read everything.

One last thing: I tried to write the line above in my vimrc as a quick workaround but it didn't work. Is that expected?

Cheers,
